### PR TITLE
fix: Add missing google-auth dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ flask
 google-generativeai
 google-cloud-aiplatform
 gunicorn
+google-auth


### PR DESCRIPTION
This commit adds the `google-auth` library to `requirements.txt`.

The library was imported in `server.py` for diagnostic logging but was not included in the dependencies, causing the application to crash with a `ModuleNotFoundError` on startup. This fix ensures the application can start correctly and that the diagnostic logs can be written.