### PR TITLE
feat: Add 'Remove Background' feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,7 @@
             <li id="context-front">Bring to Front</li>
             <li id="context-back">Send to Back</li>
             <li id="context-delete">Delete</li>
+            <li id="context-remove-background">Remove Background</li>
             <li id="context-ai-reinvent">Reinvent with AI</li>
         </ul>
     </div>

--- a/server.py
+++ b/server.py
@@ -51,6 +51,45 @@ def create_masterpiece(
     return _process_api_stream_response(stream)
 
 
+def remove_background_from_image(
+    image_paths: list[str],
+    prompt: str,
+):
+    """
+    Removes the background from an image using the Google Generative AI model.
+    """
+    api_key = os.environ.get("GOOGLE_CLOUD_API_KEY")
+    print(f"--- DEBUG: API Key found in env: {'Y' if api_key else 'N'}")
+
+    try:
+        credentials, project_id = google.auth.default()
+        print(f"--- DEBUG: ADC Credentials found. Project: {project_id}")
+        if hasattr(credentials, 'service_account_email'):
+            print(f"--- DEBUG: ADC Service Account: {credentials.service_account_email}")
+    except google.auth.exceptions.DefaultCredentialsError:
+        print("--- DEBUG: ADC Credentials not found.")
+
+    if not api_key:
+        raise ValueError("GEMINI_API_KEY environment variable not set.")
+
+    client = genai.Client(vertexai=True,project='banana-canvas-editor',location='global')
+
+    contents = _load_image_parts(image_paths)
+    contents.append(genai.types.Part.from_text(text=prompt))
+
+    generate_content_config = types.GenerateContentConfig(
+        response_modalities=["IMAGE", "TEXT"],
+    )
+
+    stream = client.models.generate_content_stream(
+        model=NANO_BANANA_MODEL_NAME,
+        contents=contents,
+        config=generate_content_config,
+    )
+
+    return _process_api_stream_response(stream)
+
+
 def remix_images(
     image_paths: list[str],
     prompt: str,
@@ -134,6 +173,48 @@ app = Flask(__name__, static_folder='static', template_folder='.')
 @app.route('/')
 def index():
     return render_template('index.html')
+
+@app.route('/remove_background', methods=['POST'])
+def remove_background():
+    if 'file' not in request.files:
+        return jsonify({"error": "No file part"}), 400
+
+    file = request.files['file']
+
+    if file.filename == '':
+        return jsonify({"error": "No selected file"}), 400
+
+    # Create a temporary directory if it doesn't exist
+    temp_dir = 'temp_uploads'
+    if not os.path.exists(temp_dir):
+        os.makedirs(temp_dir)
+
+    temp_filepath = os.path.join(temp_dir, file.filename)
+
+    try:
+        file.save(temp_filepath)
+
+        # The prompt is fixed for this operation
+        prompt = "Remove the background of this image"
+        result = remove_background_from_image([temp_filepath], prompt)
+
+        if result:
+            return send_file(
+                io.BytesIO(result['data']),
+                mimetype=result['mime_type']
+            )
+        else:
+            return jsonify({"error": "Failed to remove background"}), 500
+
+    except Exception as e:
+        print(f"Error during background removal: {e}")
+        return jsonify({"error": str(e)}), 500
+
+    finally:
+        # Clean up the uploaded file
+        if os.path.exists(temp_filepath):
+            os.remove(temp_filepath)
+
 
 @app.route('/remix', methods=['POST'])
 def remix():

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -170,6 +170,11 @@ label[for="asset-upload"]:hover {
     opacity: 0.7;
 }
 
+.canvas-item-wrapper.loading-background {
+    opacity: 0.5;
+    cursor: wait;
+}
+
 .canvas-item {
     width: 100%;
     height: 100%;


### PR DESCRIPTION
This commit introduces a new feature that allows users to remove the background from an image on the canvas.

- Adds a "Remove Background" option to the right-click context menu in `index.html`.
- Implements the client-side logic in `static/js/canvas_manager.js` to handle the feature. This includes:
  - Fetching the image data from the canvas.
  - Sending the data to a new backend endpoint.
  - Replacing the existing image with the processed one.
  - Adding a visual loading indicator during processing.
- Creates a new `/remove_background` API endpoint in `server.py` that:
  - Receives the image file.
  - Calls the generative AI model with a specific prompt to remove the background.
  - Returns the new image with a transparent background.
- Adds a new CSS class in `static/css/style.css` for the loading state.