### PR TITLE
feat: Add 'Remove Background' feature and fix bug

### DIFF
--- a/static/js/asset_manager.js
+++ b/static/js/asset_manager.js
@@ -19,6 +19,7 @@ function handleFileUpload(event) {
                 img.src = e.target.result;
                 img.title = file.name;
                 img.classList.add('asset-thumbnail');
+                img.dataset.filename = file.name;
 
                 const p = document.createElement('p');
                 p.textContent = file.name;


### PR DESCRIPTION
This commit introduces a new feature that allows users to remove the background from an image on the canvas and includes a fix for a bug that occurred with newly uploaded assets.

Feature: 'Remove Background'
- Adds a "Remove Background" option to the right-click context menu in `index.html`.
- Implements client-side logic in `static/js/canvas_manager.js` to handle the feature, including sending the image to the backend and updating it upon receiving the processed version.
- Adds a visual loading indicator in `static/css/style.css` during the operation.
- Creates a new `/remove_background` API endpoint in `server.py` to call the generative AI model for background removal.

Bug Fix:
- Resolves an issue where the background removal would fail for newly uploaded assets because the server couldn't determine the file's MIME type from a data URL.
- The original filename is now stored on the asset thumbnail in `asset_manager.js` when the file is uploaded.
- This filename is passed to the canvas item when the asset is dropped and is used in the API call, ensuring the server receives a valid filename with an extension.